### PR TITLE
Add dependancy to on Islandora

### DIFF
--- a/islandora_collection.info.yml
+++ b/islandora_collection.info.yml
@@ -3,3 +3,5 @@ type: module
 description: Islandora Collection
 core: 8.x
 package: islandora
+dependencies:
+  - islandora


### PR DESCRIPTION
Add a Drupal YAML dependancy on the Islandora base module to the
Islandora collection module.

Fixes Islandora-CLAW/CLAW#514