### PR TITLE
Add default edit and display of new Collection specific fields.

### DIFF
--- a/config/install/core.entity_form_display.fedora_resource.collection.default.yml
+++ b/config/install/core.entity_form_display.fedora_resource.collection.default.yml
@@ -1,0 +1,29 @@
+uuid: 07d53a40-68f0-44c3-9eb1-af948c595722
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.fedora_resource.collection.field_description
+    - field.field.fedora_resource.collection.field_memberof
+    - islandora.fedora_resource_type.collection
+id: fedora_resource.collection.default
+targetEntityType: fedora_resource
+bundle: collection
+mode: default
+content:
+  field_description:
+    type: string_textarea
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_memberof:
+    type: entity_reference_autocomplete
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.fedora_resource.collection.default.yml
+++ b/config/install/core.entity_view_display.fedora_resource.collection.default.yml
@@ -1,0 +1,28 @@
+uuid: b177f4ae-5ecb-4c84-b088-efe8681cfa9f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.fedora_resource.collection.field_description
+    - field.field.fedora_resource.collection.field_memberof
+    - islandora.fedora_resource_type.collection
+  module:
+    - user
+id: fedora_resource.collection.default
+targetEntityType: fedora_resource
+bundle: collection
+mode: default
+content:
+  field_description:
+    type: basic_string
+    weight: 0
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_memberof:
+    type: entity_reference_entity_id
+    weight: 0
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/field.field.fedora_resource.collection.field_memberof.yml
+++ b/config/install/field.field.fedora_resource.collection.field_memberof.yml
@@ -7,7 +7,7 @@ dependencies:
   enforced:
     module:
       - islandora_collection
-id: fedora_resource.collection5.field_memberof
+id: fedora_resource.collection.field_memberof
 field_name: field_memberof
 entity_type: fedora_resource
 bundle: collection


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/538

### How to test
Without this PR try to create a Collection... there is no way to enter the Description or Member Of by default.

1. Uninstall the islandora_collection module
1. Pull in this PR
1. Rebuild cache
1. Install the islandora_collection module
1. Create a Fedora Resource -> Collection 
1. Marvel at the two new data entry fields.
